### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       packages: write
 
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259